### PR TITLE
Collate Function Bug Fixes

### DIFF
--- a/R/collate.R
+++ b/R/collate.R
@@ -589,13 +589,13 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
 
   # Load data_description to get sensor_location for soil variables
   data_desc <- dplyr::tbl(con, "data_description") |>
+    dplyr::filter(.data$dataset_name %in% site_datasets) |>
+    dplyr::collect() |>
     dplyr::filter(
-      .data$dataset_name %in% site_datasets &
-        .data$data_variable %in% c("Soil water content", "Soil water potential")
+      grepl("Soil water content|Soil water potential", .data$data_variable, ignore.case = TRUE)
     ) |>
     dplyr::select("dataset_name", "sensor_location") |>
-    dplyr::distinct() |>
-    dplyr::collect()
+    dplyr::distinct()
 
   # Join sensor_location onto soil_var to categorize datasets
   soil_var <- soil_var |>
@@ -624,9 +624,9 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     ) |>
     dplyr::full_join(site, by = dplyr::join_by(dataset_name))
 
-  # Soil data for individuals (sensor_location == "Individual")
+  # Soil data for individuals (sensor_location == "individual")
   soil_ind <- soil_var |>
-    dplyr::filter(.data$sensor_location == "Individual")
+    dplyr::filter(.data$sensor_location == "individual")
 
   all_soil_ind <- meta_4_6 |>
     dplyr::inner_join(
@@ -645,9 +645,9 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     ) |>
     dplyr::full_join(site, by = dplyr::join_by(dataset_name))
 
-  # Soil data for plots (sensor_location == "Plot")
+  # Soil data for plots (sensor_location == "plot")
   soil_plt <- soil_var |>
-    dplyr::filter(.data$sensor_location == "Plot")
+    dplyr::filter(.data$sensor_location == "plot")
 
   all_soil_plt <- meta_4_5 |>
     dplyr::inner_join(soil_plt, by = dplyr::join_by(dataset_name, plot_id)) |>

--- a/R/collate.R
+++ b/R/collate.R
@@ -74,26 +74,16 @@ collate_met <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
   met_var <- dplyr::tbl(con, "met_var")
   site_tz <- dplyr::tbl(con, "site_tz_tmp")
 
-  # Columns in study_site that overlap with authorship (excluding join key)
-  site_cols <- dplyr::tbl(con, "study_site") |> head(0) |> dplyr::collect() |> colnames()
-  meta_cols <- dplyr::tbl(con, "authorship") |> head(0) |> dplyr::collect() |> colnames()
-  meta_drop <- setdiff(intersect(site_cols, meta_cols), "dataset_name")
-
-  meta <- dplyr::tbl(con, "authorship") |>
-    dplyr::select(!dplyr::any_of(meta_drop))
-
   # Apply dataset filter inside the DB if provided
   if (!is.null(dataset_name)) {
     site    <- site    |> dplyr::filter(.data$dataset_name %in% .env$dataset_name)
     met_var <- met_var |> dplyr::filter(.data$dataset_name %in% .env$dataset_name)
-    meta    <- meta    |> dplyr::filter(.data$dataset_name %in% .env$dataset_name)
     site_tz <- site_tz |> dplyr::filter(.data$dataset_name %in% .env$dataset_name)
   }
 
   # Perform all joins inside DuckDB (including timezone), then collect once
   all_met <- site |>
     dplyr::inner_join(met_var, by = dplyr::join_by(dataset_name)) |>
-    dplyr::left_join(meta,    by = dplyr::join_by(dataset_name)) |>
     dplyr::left_join(site_tz, by = dplyr::join_by(dataset_name)) |>
     dplyr::distinct() |>
     dplyr::collect()
@@ -210,13 +200,6 @@ collate_chamber_wp <- function(con = NULL, db_path = NULL, dataset_name = NULL) 
     dplyr::filter(.data$dataset_name %in% chamb_datasets) |>
     dplyr::collect()
 
-  # Drop columns from authorship that already exist in study_site
-  site_cols <- colnames(site)
-  meta <- dplyr::tbl(con, "authorship") |>
-    dplyr::filter(.data$dataset_name %in% chamb_datasets) |>
-    dplyr::collect() |>
-    dplyr::select(!dplyr::any_of(setdiff(site_cols, "dataset_name")))
-
   # Determine SAPFLUXNET datasets
   sfn_datasets <- sfn |>
     dplyr::filter(!is.na(.data$pl_name)) |>
@@ -264,8 +247,7 @@ collate_chamber_wp <- function(con = NULL, db_path = NULL, dataset_name = NULL) 
         .default = FALSE
       )
     ) |>
-    dplyr::inner_join(all_chamber, by = dplyr::join_by(dataset_name)) |>
-    dplyr::left_join(meta, by = dplyr::join_by(dataset_name))
+    dplyr::inner_join(all_chamber, by = dplyr::join_by(dataset_name))
 
   return(all_chamber_joined)
 }
@@ -387,13 +369,6 @@ collate_auto_wp <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     dplyr::filter(.data$dataset_name %in% auto_datasets) |>
     dplyr::collect()
 
-  # Drop columns from authorship that already exist in study_site
-  site_cols <- colnames(site)
-  meta <- dplyr::tbl(con, "authorship") |>
-    dplyr::filter(.data$dataset_name %in% auto_datasets) |>
-    dplyr::collect() |>
-    dplyr::select(!dplyr::any_of(setdiff(site_cols, "dataset_name")))
-
   # Determine SAPFLUXNET datasets
   sfn_datasets <- sfn |>
     dplyr::filter(!is.na(.data$pl_name) | !is.na(.data$pl_code)) |>
@@ -467,8 +442,7 @@ collate_auto_wp <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
         dplyr::between(date, start_date, end_date, bounds = "[)")
       )
     ) |>
-    dplyr::filter(!is.na(.data$water_potential_mean)) |>
-    dplyr::left_join(meta, by = dplyr::join_by(dataset_name))
+    dplyr::filter(!is.na(.data$water_potential_mean))
 
   return(all_auto)
 }
@@ -580,13 +554,6 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     dplyr::filter(.data$dataset_name %in% site_datasets) |>
     dplyr::collect()
 
-  # Drop columns from authorship that already exist in study_site
-  site_cols <- colnames(site)
-  meta <- dplyr::tbl(con, "authorship") |>
-    dplyr::filter(.data$dataset_name %in% site_datasets) |>
-    dplyr::select(!dplyr::any_of(setdiff(site_cols, "dataset_name"))) |>
-    dplyr::collect()
-
   # Load data_description to get sensor_location for soil variables
   data_desc <- dplyr::tbl(con, "data_description") |>
     dplyr::filter(.data$dataset_name %in% site_datasets) |>
@@ -599,7 +566,7 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
 
   # Join sensor_location onto soil_var to categorize datasets
   soil_var <- soil_var |>
-    dplyr::left_join(data_desc, by = dplyr::join_by(dataset_name)) |>
+    dplyr::left_join(data_desc, by = dplyr::join_by(dataset_name), relationship = "many-to-many") |>
     dplyr::filter(dplyr::if_any(
       dplyr::any_of(c("swc_mean_shallow", "swc_mean_deep", "swp_mean_shallow", "swp_mean_deep")),
       ~ !is.na(.x)
@@ -632,8 +599,7 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     dplyr::inner_join(
       soil_ind,
       by = dplyr::join_by(dataset_name, plot_id, individual_id)
-    ) |>
-    dplyr::left_join(meta, by = dplyr::join_by(dataset_name))
+    )
 
   # --- Plot Level ---
   # Metadata for plot level (site/trt/plt)
@@ -650,8 +616,7 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     dplyr::filter(.data$sensor_location == "plot")
 
   all_soil_plt <- meta_4_5 |>
-    dplyr::inner_join(soil_plt, by = dplyr::join_by(dataset_name, plot_id)) |>
-    dplyr::left_join(meta, by = dplyr::join_by(dataset_name))
+    dplyr::inner_join(soil_plt, by = dplyr::join_by(dataset_name, plot_id))
 
   # --- Whole Study Level ---
   # Soil data for whole study (sensor_location == "Whole study")
@@ -659,8 +624,7 @@ collate_soil <- function(con = NULL, db_path = NULL, dataset_name = NULL) {
     dplyr::filter(.data$sensor_location == "Whole study")
 
   all_soil_study <- site |>
-    dplyr::inner_join(soil_study, by = dplyr::join_by(dataset_name)) |>
-    dplyr::left_join(meta, by = dplyr::join_by(dataset_name))
+    dplyr::inner_join(soil_study, by = dplyr::join_by(dataset_name))
 
   # Return named list
   return(list(

--- a/tests/testthat/test-collate.R
+++ b/tests/testthat/test-collate.R
@@ -153,11 +153,11 @@ test_that("collate_soil returns a named list with three data frames and meta col
 
   # Verify sensor_location values match the expected level
   if (nrow(result$individual) > 0) {
-    expect_true(all(result$individual$sensor_location == "Individual"))
+    expect_true(all(result$individual$sensor_location == "individual"))
     expect_true("submitting_author_first_name" %in% colnames(result$individual))
   }
   if (nrow(result$plot) > 0) {
-    expect_true(all(result$plot$sensor_location == "Plot"))
+    expect_true(all(result$plot$sensor_location == "plot"))
     expect_true("submitting_author_first_name" %in% colnames(result$plot))
   }
   if (nrow(result$study) > 0) {

--- a/tests/testthat/test-collate.R
+++ b/tests/testthat/test-collate.R
@@ -83,7 +83,7 @@ test_that("collate functions don't close provided connections", {
 })
 
 # Test return structures
-test_that("collate_met returns a data frame with meta columns", {
+test_that("collate_met returns a data frame with expected columns", {
   skip_if_not(file.exists(get_db_path(dir = test_path("../.."))), message = "Database not found")
 
   result <- collate_met(db_path = get_db_path(dir = test_path("../..")))
@@ -92,11 +92,9 @@ test_that("collate_met returns a data frame with meta columns", {
   expect_true(nrow(result) > 0)
   expect_true("dataset_name" %in% colnames(result))
   expect_true("timezone" %in% colnames(result))
-  # Meta table columns should be present via left join
-  expect_true("submitting_author_first_name" %in% colnames(result))
 })
 
-test_that("collate_chamber_wp returns a data frame with SFN and meta columns", {
+test_that("collate_chamber_wp returns a data frame with SFN column", {
   skip_if_not(file.exists(get_db_path(dir = test_path("../.."))), message = "Database not found")
 
   result <- collate_chamber_wp(db_path = get_db_path(dir = test_path("../..")))
@@ -106,11 +104,9 @@ test_that("collate_chamber_wp returns a data frame with SFN and meta columns", {
   expect_true("SFN" %in% colnames(result))
   expect_true("timezone" %in% colnames(result))
   expect_type(result$SFN, "logical")
-  # Meta table columns should be present via left join
-  expect_true("submitting_author_first_name" %in% colnames(result))
 })
 
-test_that("collate_auto_wp returns a data frame with SFN and meta columns", {
+test_that("collate_auto_wp returns a data frame with SFN column", {
   skip_if_not(file.exists(get_db_path(dir = test_path("../.."))), message = "Database not found")
 
   result <- collate_auto_wp(db_path = get_db_path(dir = test_path("../..")))
@@ -121,11 +117,9 @@ test_that("collate_auto_wp returns a data frame with SFN and meta columns", {
   expect_true("sensor_id" %in% colnames(result))
   expect_true("timezone" %in% colnames(result))
   expect_type(result$SFN, "logical")
-  # Meta table columns should be present via left join
-  expect_true("submitting_author_first_name" %in% colnames(result))
 })
 
-test_that("collate_soil returns a named list with three data frames and meta columns", {
+test_that("collate_soil returns a named list with three data frames", {
   skip_if_not(file.exists(get_db_path(dir = test_path("../.."))), message = "Database not found")
 
   result <- collate_soil(db_path = get_db_path(dir = test_path("../..")))
@@ -154,15 +148,12 @@ test_that("collate_soil returns a named list with three data frames and meta col
   # Verify sensor_location values match the expected level
   if (nrow(result$individual) > 0) {
     expect_true(all(result$individual$sensor_location == "individual"))
-    expect_true("submitting_author_first_name" %in% colnames(result$individual))
   }
   if (nrow(result$plot) > 0) {
     expect_true(all(result$plot$sensor_location == "plot"))
-    expect_true("submitting_author_first_name" %in% colnames(result$plot))
   }
   if (nrow(result$study) > 0) {
     expect_true(all(result$study$sensor_location == "Whole study"))
-    expect_true("submitting_author_first_name" %in% colnames(result$study))
   }
 })
 

--- a/vignettes/data-analysis-examples.R
+++ b/vignettes/data-analysis-examples.R
@@ -1,0 +1,379 @@
+## ----include = FALSE----------------------------------------------------------
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE  # Set to FALSE since we don't have actual data during package build
+)
+
+
+## ----setup--------------------------------------------------------------------
+library(PSInetR)
+library(DBI)
+library(duckdb)
+library(dplyr)
+library(dbplyr)
+library(ggplot2)
+library(lubridate)
+library(tidyr)
+
+
+## ----basic-exploration--------------------------------------------------------
+# Connect to the DuckDB database
+db_path <- get_db_path()
+con <- dbConnect(duckdb::duckdb(), db_path)
+
+# List available tables
+dbListTables(con)
+
+# Preview the study sites
+study_sites <- tbl(con, "study_site") |>
+  collect()
+head(study_sites)
+
+# Count plants by species
+species_counts <- tbl(con, "plant") |>
+  group_by(genus, specific_epithet) |>
+  summarize(plant_count = n()) |>
+  arrange(desc(plant_count)) |>
+  collect()
+head(species_counts)
+
+# Don't forget to disconnect
+dbDisconnect(con, shutdown = TRUE)
+
+
+## ----water-potential----------------------------------------------------------
+# Connect to the database
+db_path <- get_db_path()
+con <- dbConnect(duckdb::duckdb(), db_path)
+
+# Get water potential data for a specific plant - Quercus alba
+quercus_ids <- tbl(con, "plant") |> 
+  filter(genus == "Quercus") 
+
+# right join by filtered dataset above
+wp_quercus <- tbl(con, "chamber_wp") |> 
+  right_join(quercus_ids, by = c("dataset_name", "individual_id", "plot_id"))
+
+# collect just to check and see dimensions
+wp_quercus|> collect()
+
+# Plot water potential vs leaf area
+wp_quercus |> 
+  collect() |>
+  drop_na(leaf_area_index_m2_m2) |> 
+  ggplot(aes(x = leaf_area_index_m2_m2, y = water_potential_mean)) +
+  geom_point() +
+  labs(title = "Quercus Water Potential by Leaf Area",
+       x = "Leaf Area (m2)",
+       y = "Water Potential (MPa)") +
+  theme_minimal()
+
+# Disconnect
+dbDisconnect(con, shutdown = TRUE)
+
+
+## ----combined-analysis--------------------------------------------------------
+# Connect to the database
+db_path <- get_db_path()
+con <- dbConnect(duckdb::duckdb(), db_path)
+
+# Get plants, water potential, and environmental data for a study site
+study <- "Ben_1"
+
+# Get water potential data
+wp_data <- tbl(con, "chamber_wp") |>
+  filter(dataset_name == study) |>
+  collect()
+
+# Get meteorological data
+met_data <- tbl(con, "met_var") |>
+  filter(dataset_name == study) |>
+  collect()
+
+# Join water potential and VPD data by date and time
+combined_data <- wp_data |>
+  inner_join(met_data, by = c("dataset_name", "date", "time")) |>
+  select(date, water_potential_mean, vapor_pressure_deficit_k_pa, 
+         air_temperature_c, precipitation_mm)
+
+# Plot water potential vs. VPD
+combined_data |>
+  ggplot(aes(x = vapor_pressure_deficit_k_pa, y = water_potential_mean)) +
+  geom_point() +
+  geom_smooth(method = "lm") +
+  labs(title = "Plant Water Potential vs. Vapor Pressure Deficit",
+       x = "VPD (kPa)",
+       y = "Water Potential (MPa)") +
+  theme_minimal()
+
+# Disconnect
+dbDisconnect(con, shutdown = TRUE)
+
+
+## ----time-analysis------------------------------------------------------------
+# Connect to the database
+db_path <- get_db_path()
+con <- dbConnect(duckdb::duckdb(), db_path)
+
+# Get predawn and midday water potential measurements
+wp_data <- tbl(con, "chamber_wp") |>
+  filter(
+    organ == "stem" | organ == "leaf",
+    !is.na(water_potential_mean)
+  ) |>
+  left_join(
+    tbl(con, "plant"),
+    by = c("dataset_name", "individual_id")
+  ) |>
+  collect()
+
+# Create time of day category based on time values
+# The time column appears to contain seconds since midnight
+# Convert to hours for easier categorization
+wp_data_filtered <- wp_data |>
+  mutate(
+    # Convert character time to numeric seconds, then to hours
+    time_numeric = seconds(hms(time)),
+    hour_decimal = time_numeric / 3600,  # Convert seconds to hours
+    hour = floor(hour_decimal),          # Extract integer hour
+    minute = round((hour_decimal - hour) * 60), # Extract minutes
+    
+    # Categorize based on typical measurement times
+    # NOTE: Adjust these ranges based on your specific measurement protocols
+    time_of_day = case_when(
+      hour >= 4 & hour <= 7 ~ "Predawn",    # 4:00 AM to 7:59 AM
+      hour >= 11 & hour <= 14 ~ "Midday",   # 11:00 AM to 2:59 PM
+      TRUE ~ "Other"
+    )
+  ) |>
+  filter(time_of_day %in% c("Predawn", "Midday"))
+
+# Alternative approach if you want to see what times are actually present:
+# wp_data |>
+#   mutate(
+#     time_numeric = seconds(hms(time)),
+#     hour_decimal = time_numeric / 3600,
+#     hour = floor(hour_decimal),
+#     minute = round((hour_decimal - hour) * 60),
+#     clock_time = sprintf("%02d:%02d", hour, minute)
+#   ) |>
+#   count(clock_time, sort = TRUE) |>
+#   head(20)  # This will show you the most common measurement times
+
+# Visualize water potential patterns by time of day and species
+wp_data_filtered |>
+  add_count(genus) |>
+  filter(n >= 500) |>  # Adjust threshold as needed
+  ggplot(aes(x = water_potential_mean, y = genus, fill = time_of_day)) +
+  geom_boxplot() +
+  labs(
+    title = "Water Potential by Species and Time of Day",
+    x = "Water Potential (MPa)",
+    y = "Genus",
+    fill = "Time of Day"
+  ) +
+  theme_minimal()
+
+# Disconnect
+dbDisconnect(con, shutdown = TRUE)
+
+
+## ----multi-table--------------------------------------------------------------
+# Connect to the database
+db_path <- get_db_path()
+con <- dbConnect(duckdb::duckdb(), db_path)
+
+# Simple multi-table join: water potential + plant species + study sites
+multi_table_data <- tbl(con, "chamber_wp") |>
+  # Join with plant table to get species information
+  inner_join(tbl(con, "plant"), by = c("dataset_name", "individual_id")) |>
+  # Join with study site table to get location information  
+  inner_join(tbl(con, "study_site"), by = "dataset_name") |>
+  # Filter for good quality data
+  filter(!is.na(water_potential_mean), !is.na(genus)) |>
+  # Select key columns
+  select(dataset_name, genus, specific_epithet, water_potential_mean, 
+         organ, latitude_wgs84, begin_year, end_year) |>
+  collect()
+
+# Summarize by genus across different studies
+genus_summary <- multi_table_data |>
+  group_by(genus) |>
+  summarize(
+    mean_wp = mean(water_potential_mean, na.rm = TRUE),
+    n_measurements = n(),
+    n_studies = n_distinct(dataset_name),
+    .groups = "drop"
+  ) |>
+  # Focus on genera with data from multiple studies
+  filter(n_studies >= 2, n_measurements >= 20) |>
+  arrange(mean_wp)
+
+# Plot 1: Water potential by genus (for genera in multiple studies)
+genus_summary |>
+  ggplot(aes(x = reorder(genus, mean_wp), y = mean_wp)) +
+  geom_col(fill = "steelblue", alpha = 0.7) +
+  geom_text(aes(label = paste0("n=", n_measurements)), 
+            hjust = -0.1, size = 3) +
+  coord_flip() +
+  labs(
+    title = "Mean Water Potential by Genus",
+    subtitle = "Genera with data from multiple studies (≥20 measurements)",
+    x = "Genus",
+    y = "Mean Water Potential (MPa)"
+  ) +
+  theme_minimal()
+
+# Plot 2: Study timeline showing data collection periods
+study_timeline <- multi_table_data |>
+  select(dataset_name, begin_year, end_year, latitude_wgs84) |>
+  distinct() |>
+  filter(!is.na(begin_year), !is.na(end_year)) |>
+  mutate(
+    study_duration = end_year - begin_year + 1,
+    latitude_group = ifelse(latitude_wgs84 >= 35, "Northern", "Southern")
+  )
+
+study_timeline |>
+  # filter for reasonable subset
+  filter(study_duration >= 6 | begin_year >= 2020) |>
+  ggplot(aes(x = begin_year, xend = end_year, 
+             y = reorder(dataset_name, begin_year), yend = reorder(dataset_name, begin_year),
+             color = latitude_group)) +
+  geom_segment(linewidth = 2, alpha = 0.7) +
+  geom_point(aes(x = begin_year), size = 0.5) +
+  geom_point(aes(x = end_year), size = 0.5) +
+  labs(
+    title = "Study Timeline and Geographic Distribution",
+    x = "Year",
+    y = "Study",
+    color = "Region"
+  ) +
+  theme_minimal() +
+  theme(axis.text.y = element_text(size = 8))
+
+# Print summary
+cat("Multi-table join results:\n")
+cat("Total water potential measurements:", nrow(multi_table_data), "\n") 
+cat("Number of genera:", length(unique(multi_table_data$genus)), "\n")
+cat("Number of studies:", length(unique(multi_table_data$dataset_name)), "\n")
+cat("Year range:", min(multi_table_data$begin_year, na.rm = TRUE), "-", 
+    max(multi_table_data$end_year, na.rm = TRUE), "\n")
+
+# Disconnect
+dbDisconnect(con, shutdown = TRUE)
+
+
+## ----seasonal-----------------------------------------------------------------
+# Connect to the database
+db_path <- get_db_path()
+con <- dbConnect(duckdb::duckdb(), db_path)
+
+# Extract seasonal patterns
+seasonal_data <- tbl(con, "chamber_wp") |>
+  inner_join(tbl(con, "plant"), by = c("dataset_name", "individual_id")) |>
+  filter(!is.na(water_potential_mean)) |>
+  collect() |>
+  mutate(
+    # Extract date components
+    year = year(date),
+    month = month(date),
+    day = day(date),
+    # Create day of year
+    date_parsed = as.Date(paste(year, month, day, sep = "-")),
+    day_of_year = as.numeric(format(date_parsed, "%j"))
+  ) |>
+  filter(!is.na(day_of_year))
+
+# Plot seasonal patterns - this plots a lot of data and takes a while
+seasonal_data |>
+  ggplot(aes(x = day_of_year, y = water_potential_mean)) +
+  geom_hex() + 
+  # geom_smooth(method = "loess", se = TRUE) +
+  # facet_wrap(~genus, scales = "free_y") + # could also facet by genus
+  labs(
+    title = "Seasonal Patterns in Water Potential",
+    x = "Day of Year",
+    y = "Water Potential (MPa)"
+  ) +
+  theme_minimal()
+
+# Disconnect
+dbDisconnect(con, shutdown = TRUE)
+
+
+## ----spatial, eval=FALSE------------------------------------------------------
+# # If you have spatial analysis needs
+# library(sf)
+# 
+# # Connect to database
+# con <- dbConnect(duckdb::duckdb(), get_db_path())
+# 
+# # Get study site locations
+# site_locations <- tbl(con, "study_site") |>
+#   filter(!is.na(latitude_wgs84), !is.na(longitude_wgs84)) |>
+#   collect() |>
+#   st_as_sf(coords = c("longitude_wgs84", "latitude_wgs84"), crs = 4326)
+# 
+# # Now you can use spatial analysis functions
+# dbDisconnect(con, shutdown = TRUE)
+
+
+## ----timeseries, eval=FALSE---------------------------------------------------
+# # For time series analysis
+# library(lubridate)
+# library(forecast)
+# 
+# con <- dbConnect(duckdb::duckdb(), get_db_path())
+# 
+# # Get time series data for a specific site/species
+# ts_data <- tbl(con, "chamber_wp") |>
+#   inner_join(tbl(con, "plant"), by = c("dataset_name", "individual_id")) |>
+#   filter(dataset_name == "Ada_1", genus == "Thuja") |>
+#   collect() |>
+#   mutate(
+#     date_time = ymd(date) + seconds(hms(time))
+#   ) |>
+#   arrange(date_time)
+# 
+# # Create a complete time series by aggregating to daily means
+# daily_wp <- ts_data |>
+#   mutate(date_only = as.Date(date_time)) |>
+#   group_by(date_only) |>
+#   summarize(
+#     mean_wp = mean(water_potential_mean, na.rm = TRUE),
+#     n_obs = n(),
+#     .groups = "drop"
+#   ) |>
+#   arrange(date_only)
+# 
+# # Plot the time series
+# ggplot(daily_wp, aes(x = date_only, y = mean_wp)) +
+#   geom_line() +
+#   geom_smooth(method = "loess", se = TRUE, color = "blue") +
+#   labs(
+#     title = "Daily Mean Water Potential Time Series",
+#     x = "Date",
+#     y = "Water Potential (MPa)"
+#   ) +
+#   theme_minimal()
+# 
+# # Autocorrelation analysis
+# acf_result <- acf(daily_wp$mean_wp, na.action = na.pass, plot = TRUE,
+#                   main = "Autocorrelation of Water Potential")
+# 
+# # Decompose the time series if there's enough data
+# if (nrow(daily_wp) >= 365) {
+#   # Create regular time series object
+#   ts_wp <- ts(daily_wp$mean_wp, frequency = 365)
+# 
+#   # Decompose into trend, seasonal, and random components
+#   decomp <- decompose(ts_wp, type = "additive")
+# 
+#   # Plot decomposition
+#   plot(decomp, main = "Time Series Decomposition")
+# }
+# 
+# dbDisconnect(con, shutdown = TRUE)
+

--- a/vignettes/getting-started.R
+++ b/vignettes/getting-started.R
@@ -13,201 +13,40 @@ library(PSInetR)
 # # Download data from repository as DuckDB (default)
 # get_psi_data()
 # 
-# # Download data from Zenodo as CSV files
-# get_psi_data(source = "zenodo", format = "csv")
+# # Download individual CSV files from Zenodo (forthcoming)
+# # get_psi_data(source = "zenodo", format = "csv")
 # 
 # # If the repository is private, provide a GitHub token
 # get_psi_data(github_token = "your_github_token")
+# 
+# # Alternatively, store your GitHub token in .Renviron file:
+# # GITHUB_PAT=your_github_token_here
+# # Then simply call:
+# # get_psi_data()
 
 
-## ----checking, eval=FALSE-----------------------------------------------------
-# # Check if DuckDB data is available
-# check_psi_data()
-# 
-# # Check if CSV data is available
-# check_psi_data(format = "csv")
-# 
-# # Check and validate the data
-# check_psi_data(validate = TRUE, dir = "/Users/keatonwilson/Documents/Projects/PSInetR/vignettes/")
-
-
-## ----basic-exploration, eval=FALSE--------------------------------------------
-# library(DBI)
-# library(duckdb)
-# library(dplyr)
-# library(dbplyr)
-# 
-# # Connect to the DuckDB database
-# db_path <- get_db_path()
-# con <- dbConnect(duckdb::duckdb(), db_path)
-# 
-# # List available tables
-# dbListTables(con)
-# 
-# # Preview the study sites
-# study_sites <- tbl(con, "study_site") |>
-#   collect()
-# head(study_sites)
-# 
-# # Count plants by species
-# species_counts <- tbl(con, "plants") |>
-#   group_by(genus, specific_epithet) |>
-#   summarize(plant_count = n()) |>
-#   arrange(desc(plant_count)) |>
-#   collect()
-# head(species_counts)
-# 
-# # Don't forget to disconnect
-# dbDisconnect(con, shutdown = TRUE)
-
-
-## ----water-potential, eval=FALSE----------------------------------------------
-# library(DBI)
-# library(duckdb)
-# library(dplyr)
-# library(dbplyr)
-# library(ggplot2)
-# 
-# # Connect to the database
-# db_path <- get_db_path()
-# con <- dbConnect(duckdb::duckdb(), db_path)
-# 
-# # Get water potential data for a specific plant - Sorghum bicolor
-# sorghum_ids <- tbl(con, "plant_types") |>
-#   filter(genus == "Sorghum" & specific_epithet == "bicolor")
-# 
-# # right join by filtered dataset above
-# wp_sorg <- tbl(con, "press_chamb_wb") |>
-#   right_join(sorghum_ids, by = c("dataset_name", "individual_id"))
-# 
-# # collect just to check and see dimensions
-# wp_sorg |> collect()
-# 
-# # Plot water potential vs leaf area
-# wp_sorg |>
-#   ggplot(aes(x = leaf_area_index_m2_m2, y = water_potential_mean)) +
-#   geom_point() +
-#   labs(title = "Sorghum Water Potential by Leaf Area",
-#        x = "Leaf Area (m2)",
-#        y = "Water Potential (MPa)") +
-#   theme_minimal()
-# 
-# # Disconnect
-# dbDisconnect(con, shutdown = TRUE)
-
-
-## ----combined-analysis, eval=FALSE--------------------------------------------
-# library(DBI)
-# library(duckdb)
-# library(dplyr)
-# library(ggplot2)
-# 
-# # Connect to the database
-# db_path <- get_db_path()
-# con <- dbConnect(duckdb::duckdb(), db_path)
-# 
-# # Get plants, water potential, and environmental data for a study site
-# study <- "Ben_1"
-# 
-# # Get water potential data
-# wp_data <- tbl(con, "press_chamb_wb") |>
-#   filter(dataset_name == study) |>
-#   collect()
-# 
-# # Get environmental data
-# env_data <- tbl(con, "env_vars") |>
-#   filter(dataset_name == study) |>
-#   collect()
-# 
-# # Join water potential and VPD data by date and time
-# combined_data <- wp_data |>
-#   inner_join(env_data, by = c("dataset_name", "date", "time")) |>
-#   select(date, water_potential_mean, vapor_pressure_deficit_k_pa,
-#          air_temperature_c, precipitation_mm)
-# 
-# # Plot water potential vs. VPD
-# combined_data |>
-#   ggplot(aes(x = vapor_pressure_deficit_k_pa, y = water_potential_mean)) +
-#   geom_point() +
-#   geom_smooth(method = "lm") +
-#   labs(title = "Plant Water Potential vs. Vapor Pressure Deficit",
-#        x = "VPD (kPa)",
-#        y = "Water Potential (MPa)") +
-#   theme_minimal()
-# 
-# # Disconnect
-# dbDisconnect(con, shutdown = TRUE)
-
-
-## ----integration, eval=FALSE--------------------------------------------------
-# # Example: Use tidyverse for data wrangling and visualization
-# library(dplyr)
-# library(ggplot2)
+## ----basic-connection, eval=FALSE---------------------------------------------
 # library(DBI)
 # library(duckdb)
 # 
-# # Connect to the database
+# # Get the path to the database and connect
 # db_path <- get_db_path()
 # con <- dbConnect(duckdb::duckdb(), db_path)
 # 
-# # Get predawn and midday water potential measurements
-# wp_data <- tbl(con, "press_chamb_wb") |>
-#   filter(
-#     organ == "stem" | organ == "leaf",
-#     !is.na(water_potential_mean)
-#   ) |>
-#   left_join(
-#     tbl(con, "plants"),
-#     by = c("dataset_name", "individual_id")
-#   ) |>
-#   collect()
+# # List all available tables
+# tables <- dbListTables(con)
+# print(tables)
 # 
-# # Create time of day category based on time values
-# # The time column appears to contain seconds since midnight
-# # Convert to hours for easier categorization
-# wp_data_filtered <- wp_data |>
-#   mutate(
-#     # Convert character time to numeric seconds, then to hours
-#     time_numeric = as.numeric(time),
-#     hour_decimal = time_numeric / 3600,  # Convert seconds to hours
-#     hour = floor(hour_decimal),          # Extract integer hour
-#     minute = round((hour_decimal - hour) * 60), # Extract minutes
-# 
-#     # Categorize based on typical measurement times
-#     # NOTE: Adjust these ranges based on your specific measurement protocols
-#     time_of_day = case_when(
-#       hour >= 4 & hour <= 7 ~ "Predawn",    # 4:00 AM to 7:59 AM
-#       hour >= 11 & hour <= 14 ~ "Midday",   # 11:00 AM to 2:59 PM
-#       TRUE ~ "Other"
-#     )
-#   ) |>
-#   filter(time_of_day %in% c("Predawn", "Midday"))
-# 
-# # Alternative approach if you want to see what times are actually present:
-# # wp_data |>
-# #   mutate(
-# #     time_numeric = as.numeric(time),
-# #     hour_decimal = time_numeric / 3600,
-# #     hour = floor(hour_decimal),
-# #     minute = round((hour_decimal - hour) * 60),
-# #     clock_time = sprintf("%02d:%02d", hour, minute)
-# #   ) |>
-# #   count(clock_time, sort = TRUE) |>
-# #   head(20)  # This will show you the most common measurement times
-# 
-# # Visualize water potential patterns by time of day and species
-# wp_data_filtered %>%
-#   ggplot(aes(x = genus, y = water_potential_mean, fill = time_of_day)) +
-#   geom_boxplot() +
-#   labs(
-#     title = "Water Potential by Species and Time of Day",
-#     x = "Genus",
-#     y = "Water Potential (MPa)",
-#     fill = "Time of Day"
-#   ) +
-#   theme_minimal() +
-#   theme(axis.text.x = element_text(angle = 45, hjust = 1))
-# 
-# # Disconnect
+# # Always disconnect when finished
 # dbDisconnect(con, shutdown = TRUE)
+
+
+## ----next-steps, eval=FALSE---------------------------------------------------
+# # View the examples vignette
+# vignette("data-analysis-examples", package = "PSInetR")
+
+
+## ----advanced, eval=FALSE-----------------------------------------------------
+# # View the DuckDB vignette
+# vignette("working-with-duckdb", package = "PSInetR")
 

--- a/vignettes/working-with-duckdb.R
+++ b/vignettes/working-with-duckdb.R
@@ -11,6 +11,7 @@ library(PSInetR)
 library(dplyr)
 library(DBI)
 library(duckdb)
+library(lubridate)
 
 
 ## ----connect------------------------------------------------------------------
@@ -44,41 +45,62 @@ db_schema <- DBI::dbGetQuery(con, "
 ")
 
 # View the schema of a specific table
-press_chamb_fields <- dbListFields(con, "press_chamb_wp")
-print(press_chamb_fields)
+chamber_wp_fields <- dbListFields(con, "chamber_wp")
+print(chamber_wp_fields)
+
+# Check the dimensions of core tables
+core_tables <- c("study_site", "plot", "plant", "treatment", "data_description", "addtl_data", "authorship")
+for(table in core_tables) {
+  count <- dbGetQuery(con, paste("SELECT COUNT(*) as count FROM", table))
+  cat(table, ":", count$count, "records\n")
+}
+
+# Check the dimensions of measurement tables  
+measurement_tables <- c("chamber_wp", "auto_wp", "soil_var", "met_var", "auto_wp_sensor")
+for(table in measurement_tables) {
+  count <- dbGetQuery(con, paste("SELECT COUNT(*) as count FROM", table))
+  cat(table, ":", count$count, "records\n")
+}
 
 
 ## ----basic_queries------------------------------------------------------------
 # Get a list of all study sites
-study_sites <- dbGetQuery(con, "SELECT dataset_name, latitude_wgs84, longitude_wgs84 FROM study_site LIMIT 10")
+study_sites <- tbl(con, "study_site") |>
+  select(dataset_name, latitude_wgs84, longitude_wgs84) |>
+  head(10) |>
+  collect()
 print(study_sites)
 
 # Get plant species information
-plant_species <- dbGetQuery(con, "SELECT DISTINCT genus, specific_epithet FROM plants LIMIT 10")
+plant_species <- tbl(con, "plant") |>
+  select(genus, specific_epithet) |>
+  distinct() |>
+  head(10) |>
+  collect()
 print(plant_species)
 
 # Get statistics on water potential measurements
-wp_stats <- dbGetQuery(con, "
-  SELECT 
-    COUNT(*) as count,
-    AVG(water_potential_mean) as avg_potential,
-    MIN(water_potential_mean) as min_potential,
-    MAX(water_potential_mean) as max_potential
-  FROM press_chamb_wp
-  WHERE water_potential_mean IS NOT NULL
-")
+wp_stats <- tbl(con, "chamber_wp") |>
+  filter(!is.na(water_potential_mean)) |>
+  summarize(
+    count = n(),
+    avg_potential = mean(water_potential_mean, na.rm = TRUE),
+    min_potential = min(water_potential_mean, na.rm = TRUE),
+    max_potential = max(water_potential_mean, na.rm = TRUE)
+  ) |>
+  collect()
 print(wp_stats)
 
 
 ## ----dplyr_queries------------------------------------------------------------
 # Create references to the tables
-press_chamb_wp_tbl <- tbl(con, "press_chamb_wp")
-plants_tbl <- tbl(con, "plants")
-plots_tbl <- tbl(con, "plots")
+chamber_wp_tbl <- tbl(con, "chamber_wp")
+plant_tbl <- tbl(con, "plant")
+plot_tbl <- tbl(con, "plot")
 
 # Query using dplyr syntax for water potential by species
-wp_by_species <- press_chamb_wp_tbl |>
-  inner_join(plants_tbl, by = c("dataset_name", "individual_id")) |>
+wp_by_species <- chamber_wp_tbl |>
+  inner_join(plant_tbl, by = c("dataset_name", "individual_id")) |>
   group_by(genus, specific_epithet) |>
   summarize(
     count = n(),
@@ -92,7 +114,7 @@ wp_by_species <- press_chamb_wp_tbl |>
 print(wp_by_species)
 
 # Find measurements by organ type
-organ_summary <- press_chamb_wp_tbl |>
+organ_summary <- chamber_wp_tbl |>
   group_by(organ, canopy_position) |>
   summarize(
     count = n(),
@@ -108,12 +130,12 @@ print(organ_summary)
 
 ## ----advanced_analyses--------------------------------------------------------
 # Analyze seasonal patterns in water potential
-seasonal_patterns <- press_chamb_wp_tbl |>
+seasonal_patterns <- chamber_wp_tbl |>
   # must collect first because substr can't be run by db
   collect() |>
   # Extract month from date (YYYYMMDD format)
-  mutate(month = substr(date, 5, 6)) |>
-  group_by(month) %>%
+  mutate(month = month(date)) |>
+  group_by(month) |>
   summarize(
     avg_potential = mean(water_potential_mean, na.rm = TRUE),
     sd_potential = sd(water_potential_mean, na.rm = TRUE),
@@ -122,11 +144,11 @@ seasonal_patterns <- press_chamb_wp_tbl |>
 
 print(seasonal_patterns)
 
-# Comparing water potential with soil moisture
-soil_wp_comparison <- press_chamb_wp_tbl |>
-  # Join with soil moisture data on dataset_name, plot_id, and date
+# Comparing water potential with soil variables
+soil_wp_comparison <- chamber_wp_tbl |>
+  # Join with soil data on dataset_name, plot_id, and date
   inner_join(
-    tbl(con, "soil_moisture"),
+    tbl(con, "soil_var"),
     by = c("dataset_name", "plot_id", "date")
   ) |>
   # Group by soil moisture categories (using a window function)
@@ -137,22 +159,22 @@ soil_wp_comparison <- press_chamb_wp_tbl |>
       swc_mean_shallow < 0.3 ~ "medium",
       TRUE ~ "high"
     )
-  ) %>%
-  group_by(swc_shallow_category) %>%
+  ) |>
+  group_by(swc_shallow_category) |>
   summarize(
     avg_water_potential = mean(water_potential_mean, na.rm = TRUE),
     sd_water_potential = sd(water_potential_mean, na.rm = TRUE),
     n_observations = n()
-  ) %>%
+  ) |>
   collect()
 
 print(soil_wp_comparison)
 
-# Analyzing the relationship between environmental variables and water potential
-env_wp_comparison <- press_chamb_wp_tbl |>
-  # Join with environmental data on dataset_name and date
+# Analyzing the relationship between meteorological variables and water potential
+met_wp_comparison <- chamber_wp_tbl |>
+  # Join with meteorological data on dataset_name and date
   inner_join(
-    tbl(con, "env_vars"),
+    tbl(con, "met_var"),
     by = c("dataset_name", "date")
   ) |>
   # Select relevant columns
@@ -173,7 +195,7 @@ env_wp_comparison <- press_chamb_wp_tbl |>
     n_observations = n()
   ) 
 
-print(env_wp_comparison)
+print(met_wp_comparison)
 
 
 
@@ -182,14 +204,14 @@ library(ggplot2)
 library(lubridate)
 
 # Get water potential data for visualization
-wp_time_data <- tbl(con, "press_chamb_wp") |>
+wp_time_data <- tbl(con, "chamber_wp") |>
   filter(!is.na(water_potential_mean)) |>
   collect() |>
   mutate(date_parsed = ymd(as.character(date)))  # Convert YYYYMMDD to Date
 
 # Get water potential by species
-wp_species <- tbl(con, "press_chamb_wp") |>
-  inner_join(tbl(con, "plants"), by = c("dataset_name", "individual_id", "plot_id")) %>%
+wp_species <- tbl(con, "chamber_wp") |>
+  inner_join(tbl(con, "plant"), by = c("dataset_name", "individual_id", "plot_id")) |>
   group_by(genus, specific_epithet) |>
   summarize(
     mean_wp = mean(water_potential_mean, na.rm = TRUE),
@@ -202,16 +224,22 @@ wp_species <- tbl(con, "press_chamb_wp") |>
 # Create species name
 wp_species$species <- paste(wp_species$genus, wp_species$specific_epithet)
 
-# Plot water potential by species
-ggplot(wp_species, aes(x = reorder(species, mean_wp), y = mean_wp)) +
-  geom_bar(stat = "identity") +
+# Show only the 20 species with most extreme (lowest) water potentials
+top_species <- wp_species |>
+  arrange(mean_wp) |>
+  head(20)
+
+top_species$species <- paste(top_species$genus, top_species$specific_epithet)
+
+ggplot(top_species, aes(x = reorder(species, mean_wp), y = mean_wp)) +
+  geom_bar(stat = "identity", fill = "steelblue") +
   geom_errorbar(aes(ymin = mean_wp - sd_wp, ymax = mean_wp + sd_wp), width = 0.2) +
   labs(
-    title = "Average Water Potential by Species",
+    title = "Top 20 Species with Lowest Water Potential",
     x = "Species",
     y = "Water Potential (MPa)"
   ) +
-  coord_flip() +  # Flip coordinates for better readability
+  coord_flip() +
   theme_minimal()
 
 # Don't forget to disconnect
@@ -222,45 +250,33 @@ dbDisconnect(con, shutdown = TRUE)
 # Connect to database
 con <- dbConnect(duckdb::duckdb(), get_db_path())
 
-# Query to combine manual and automated measurements
-combined_query <- "
-SELECT
-  'manual' as measurement_type,
-  pc.dataset_name,
-  pc.individual_id,
-  pc.date,
-  pc.time,
-  pc.water_potential_mean,
-  pc.water_potential_sd,
-  p.genus,
-  p.specific_epithet
-FROM press_chamb_wp pc
-JOIN plants p ON pc.dataset_name = p.dataset_name AND pc.individual_id = p.individual_id
-WHERE pc.water_potential_mean IS NOT NULL
+# Combine automated and manual measurements using dplyr
+# First get automated measurements
+auto_data <- tbl(con, "auto_wp") |>
+  inner_join(tbl(con, "plant"), by = c("dataset_name", "individual_id")) |>
+  filter(!is.na(water_potential_mean)) |>
+  select(dataset_name, individual_id, date, time, 
+         water_potential_mean, water_potential_sd, genus, specific_epithet) |>
+  mutate(measurement_type = "automated") |>
+  head(500) |>  # Limit to avoid memory issues
+  collect()
 
-UNION ALL
+# Then get manual measurements  
+manual_data <- tbl(con, "chamber_wp") |>
+  inner_join(tbl(con, "plant"), by = c("dataset_name", "individual_id")) |>
+  filter(!is.na(water_potential_mean)) |>
+  select(dataset_name, individual_id, date, time,
+         water_potential_mean, water_potential_sd, genus, specific_epithet) |>
+  mutate(measurement_type = "manual") |>
+  head(500) |>  # Limit to avoid memory issues
+  collect()
 
-SELECT
-  'automated' as measurement_type,
-  a.dataset_name,
-  a.individual_id,
-  a.date,
-  a.time,
-  a.water_potential_mean,
-  a.water_potential_sd,
-  p.genus,
-  p.specific_epithet
-FROM auto_wp a
-JOIN plants p ON a.dataset_name = p.dataset_name AND a.individual_id = p.individual_id
-WHERE a.water_potential_mean IS NOT NULL
-LIMIT 1000  -- Limit to avoid memory issues
-"
+# Combine the datasets
+combined_data <- bind_rows(auto_data, manual_data)
 
-combined_data <- dbGetQuery(con, combined_query)
-
-# Compare manual vs automated measurements
-measurement_summary <- combined_data %>%
-  group_by(measurement_type) %>%
+# Compare automated vs manual measurements
+measurement_summary <- combined_data |>
+  group_by(measurement_type) |>
   summarize(
     count = n(),
     avg_potential = mean(water_potential_mean, na.rm = TRUE),
@@ -280,9 +296,9 @@ dbDisconnect(con, shutdown = TRUE)
 con <- dbConnect(duckdb::duckdb(), get_db_path())
 
 # Efficient query - filtering happens in database
-efficient_query <- tbl(con, "press_chamb_wp") %>%
-  filter(water_potential_mean < -1.0) %>%
-  select(dataset_name, individual_id, date, water_potential_mean) %>%
+efficient_query <- tbl(con, "chamber_wp") |>
+  filter(water_potential_mean < -1.0) |>
+  select(dataset_name, individual_id, date, water_potential_mean) |>
   collect()
 
 # Disconnect


### PR DESCRIPTION
## Summary

- Fix `collate_soil()` string mismatch bug — function was searching for the wrong
sensor_location string, causing incorrect filtering
- Remove `authorship` table join from all four `collate_*()` functions (`collate_met`,
`collate_chamber_wp`, `collate_auto_wp`, `collate_soil`)

## Motivation

Authorship data is tied to the data paper (limited to two authors per dataset), not to the
dataset itself — many contributors who should be credited are excluded. Joining authorship into the collated outputs was misleading and unnecessary; users who need authorship info can join the `authorship` table directly.

## Changes

- `R/collate.R`: removed `authorship` table load, column deduplication logic, and
`left_join(meta, ...)` from all four collate functions; added `relationship = "many-to-many"` to the `soil_var`/`data_desc` join in `collate_soil` to silence a legitimate warning
- `tests/testthat/test-collate.R`: removed `submitting_author_first_name` column assertions; updated test names

## Test plan

- [x] All 69 tests pass (`devtools::test()`)
- [x] No failures; 0 warnings related to authorship removal

This closes #26 and closes #27